### PR TITLE
add external listener for ping from website

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -107,6 +107,15 @@ function NotificationsController($scope, $http) {
                 });
             }
         );
+
+        chrome.runtime.onMessageExternal.addListener(
+            function(request, sender, sendResponse) {
+              if (request.ping) {
+                sendResponse(true);
+              }
+            }
+        );
+
     };
 
     Notifications.prototype.resetBadgeText = function(value) {

--- a/manifest.json
+++ b/manifest.json
@@ -120,6 +120,9 @@
     "web_accessible_resources": [
         "icon.png"
     ],
+    "externally_connectable": {
+      "matches": ["https://www.kogan.com/*"]
+    },
     "browser_action": {
         "default_icon": "icon.png",
         "default_popup": "popup.html"


### PR DESCRIPTION
Can test in console. Will log 'true' if update is installed, undefined otherwise

```
var extensionId = yourExtensionId

window.chrome.runtime.sendMessage(extensionId, {ping: true}, function(response) { console.log(response) })
```